### PR TITLE
Fix el7 package prefix for aerospike client

### DIFF
--- a/scripts/aerospike-client-c.sh
+++ b/scripts/aerospike-client-c.sh
@@ -135,7 +135,7 @@ if [ $DOWNLOAD ] && [ $DOWNLOAD == 1 ]; then
           ;;
         "ami"* )
           PKG_VERSION="${AEROSPIKE_C_VERSION//-/_}-1"
-          PKG_SUFFIX="el6.x86_64.rpm"
+          PKG_SUFFIX="el7.x86_64.rpm"
           PKG_TYPE="rpm"
           ;;
         * )


### PR DESCRIPTION
Currently, installing aerospike client is failing with error as rpm is not available. Its because its using el6 and now aerospike is on centos7 and on aerospike url, there is not rpm for el6 as well.